### PR TITLE
Sorting fixes

### DIFF
--- a/maimai/src/js/maimai.table-config.js
+++ b/maimai/src/js/maimai.table-config.js
@@ -493,15 +493,21 @@ $(document).ready(function() {
       {
         displayTitle: "BPM",
         name: "bpm",
-        data: function(row) {
-          return extractBPM(row.bpm);
-        },
+        data: "bpm",
         defaultContent: "",
         className: "details bpm",
         customDropdownSortSource: function (row_a, row_b) {
           var a = extractBPM(row_a.bpm).padStart(3, '0');
           var b = extractBPM(row_b.bpm).padStart(3, '0');
           return a.localeCompare(b);
+        },
+        render: function ( data, type, row ) {
+          if ( type === 'display' && data ) {
+            return data;
+          }
+          else {
+            return extractBPM(row.bpm);
+          }
         },
         searchable: false,
         visible: false

--- a/maimai/src/js/maimai.table-config.js
+++ b/maimai/src/js/maimai.table-config.js
@@ -375,6 +375,14 @@ function maimaiRenderGenre() {
   }
 }
 
+function extractBPM(text) {
+  const match = text.match(/([^)]+)\(([^)]+)\)/)
+  if(match) {
+    return match.slice(1).filter(v => v.trim().length <= 3)[0]
+  } else return text;
+  
+}
+
 $(document).ready(function() {
   initTranslations().then(() => {
     columns_params = [
@@ -485,9 +493,16 @@ $(document).ready(function() {
       {
         displayTitle: "BPM",
         name: "bpm",
-        data: "bpm",
+        data: function(row) {
+          return extractBPM(row.bpm);
+        },
         defaultContent: "",
         className: "details bpm",
+        customDropdownSortSource: function (row_a, row_b) {
+          var a = extractBPM(row_a.bpm).padStart(3, '0');
+          var b = extractBPM(row_b.bpm).padStart(3, '0');
+          return a.localeCompare(b);
+        },
         searchable: false,
         visible: false
       },

--- a/maimai/src/js/maimai.table-config.js
+++ b/maimai/src/js/maimai.table-config.js
@@ -356,6 +356,25 @@ function maimaiRenderVersionName() {
   }
 }
 
+function maimaiRenderGenre() {
+  return function( row, type, set, meta ) {
+    if ( type === 'sort' || type === 'meta') {
+      const genre_list = {
+        "POPS＆アニメ": "100",
+        "niconico＆ボーカロイド": "200",
+        "東方Project": "300",
+        "ゲーム＆バラエティ": "400",
+        "maimai": "500",
+        "オンゲキ＆CHUNITHM": "600",
+        "宴会場": "999",
+      }
+      return genre_list[row.catcode];
+    } else {
+      return row.catcode
+    }
+  }
+}
+
 $(document).ready(function() {
   initTranslations().then(() => {
     columns_params = [
@@ -420,7 +439,7 @@ $(document).ready(function() {
           }
           // Else type detection or sorting data, return reading
           else {
-            return row.reading;
+            return row.title_kana;
           }
         },
         width: "80vw"
@@ -505,7 +524,7 @@ $(document).ready(function() {
         // displayTitle: "ジャンル",
         displayTitle: getTranslation(userLanguage,'col_genre'),
         name: "category",
-        data: "catcode",
+        data: maimaiRenderGenre(),
         defaultContent: "",
         className: "details category",
         render: renderInWrapper(),


### PR DESCRIPTION
fixes
- maimai songs now properly sort by their readings (key from readings -> title_kana)

addition
- genre now sort by their ingame sort (pops -> nico -> touhou -> variety -> maimai -> chuni -> utage)
- bpm now show their real BPM, and sorts by it too