### PR TITLE
feat(ongeki): update version labels to Re:Fresh Act.2 (#1185)

### DIFF
--- a/ongeki/data/music-ex.json
+++ b/ongeki/data/music-ex.json
@@ -56519,7 +56519,7 @@
     "lev_lnt_bells": "",
     "lev_lnt_designer": "",
     "lev_lnt_chart_link": "",
-    "version": "Re:Fresh",
+    "version": "Re:Fresh Act.2",
     "wikiwiki_url": "https://wikiwiki.jp/gameongeki/シークレット・シーカー"
   },
   {
@@ -56571,7 +56571,7 @@
     "lev_lnt_bells": "",
     "lev_lnt_designer": "",
     "lev_lnt_chart_link": "",
-    "version": "Re:Fresh",
+    "version": "Re:Fresh Act.2",
     "wikiwiki_url": "https://wikiwiki.jp/gameongeki/お返事まだカナ？おじさん構文！"
   },
   {
@@ -56623,7 +56623,7 @@
     "lev_lnt_bells": "",
     "lev_lnt_designer": "",
     "lev_lnt_chart_link": "",
-    "version": "Re:Fresh",
+    "version": "Re:Fresh Act.2",
     "wikiwiki_url": "https://wikiwiki.jp/gameongeki/メモリア"
   },
   {
@@ -56675,7 +56675,7 @@
     "lev_lnt_bells": "",
     "lev_lnt_designer": "",
     "lev_lnt_chart_link": "",
-    "version": "Re:Fresh",
+    "version": "Re:Fresh Act.2",
     "wikiwiki_url": "https://wikiwiki.jp/gameongeki/ももいろの鍵"
   },
   {
@@ -56727,7 +56727,7 @@
     "lev_lnt_bells": "",
     "lev_lnt_designer": "",
     "lev_lnt_chart_link": "",
-    "version": "Re:Fresh",
+    "version": "Re:Fresh Act.2",
     "wikiwiki_url": "https://wikiwiki.jp/gameongeki/熱異常"
   },
   {
@@ -56779,7 +56779,7 @@
     "lev_lnt_bells": "",
     "lev_lnt_designer": "",
     "lev_lnt_chart_link": "",
-    "version": "Re:Fresh",
+    "version": "Re:Fresh Act.2",
     "wikiwiki_url": "https://wikiwiki.jp/gameongeki/ユメハナビ"
   },
   {
@@ -56831,7 +56831,7 @@
     "lev_lnt_bells": "",
     "lev_lnt_designer": "",
     "lev_lnt_chart_link": "",
-    "version": "Re:Fresh",
+    "version": "Re:Fresh Act.2",
     "wikiwiki_url": "https://wikiwiki.jp/gameongeki/poppin’ hoppin’ flappin’☆☆☆"
   },
   {
@@ -56883,7 +56883,7 @@
     "lev_lnt_bells": "",
     "lev_lnt_designer": "",
     "lev_lnt_chart_link": "",
-    "version": "Re:Fresh",
+    "version": "Re:Fresh Act.2",
     "wikiwiki_url": ""
   },
   {
@@ -56935,7 +56935,7 @@
     "lev_lnt_bells": "",
     "lev_lnt_designer": "",
     "lev_lnt_chart_link": "",
-    "version": "Re:Fresh",
+    "version": "Re:Fresh Act.2",
     "wikiwiki_url": "https://wikiwiki.jp/gameongeki/Cryogenic"
   },
   {
@@ -56987,7 +56987,7 @@
     "lev_lnt_bells": "",
     "lev_lnt_designer": "",
     "lev_lnt_chart_link": "",
-    "version": "Re:Fresh",
+    "version": "Re:Fresh Act.2",
     "wikiwiki_url": "https://wikiwiki.jp/gameongeki/涌遊スマイルパワー"
   },
   {
@@ -57039,7 +57039,7 @@
     "lev_lnt_bells": "",
     "lev_lnt_designer": "",
     "lev_lnt_chart_link": "",
-    "version": "Re:Fresh",
+    "version": "Re:Fresh Act.2",
     "wikiwiki_url": "https://wikiwiki.jp/gameongeki/Cthugha"
   },
   {
@@ -57091,7 +57091,7 @@
     "lev_lnt_bells": "",
     "lev_lnt_designer": "",
     "lev_lnt_chart_link": "",
-    "version": "Re:Fresh",
+    "version": "Re:Fresh Act.2",
     "wikiwiki_url": "https://wikiwiki.jp/gameongeki/アルメリアの鳥籠"
   },
   {
@@ -57143,7 +57143,7 @@
     "lev_lnt_bells": "",
     "lev_lnt_designer": "",
     "lev_lnt_chart_link": "",
-    "version": "Re:Fresh",
+    "version": "Re:Fresh Act.2",
     "wikiwiki_url": "https://wikiwiki.jp/gameongeki/それはもうらぶちゅ"
   }
 ]

--- a/ongeki/src/pug/_ongeki_meta.pug
+++ b/ongeki/src/pug/_ongeki_meta.pug
@@ -2,7 +2,7 @@ block variables
   - var game_name = 'ongeki'
   - var game_name_display = 'オンゲキ'
   - var game_db_name = 'オンゲキDB'
-  - var game_version_display = 'Re:Fresh'
+  - var game_version_display = 'Re:Fresh Act.2'
   - var game_version_display_intl = ''
   - var levels = ['15+','15','14+','14','13+','13','12+','12','11+','11','10+','10','9+','9','8+','8','7+','7','6','5','4','3','2','1','0'];
   - var lastupdated_jp = '20260806'

--- a/scripts/ongeki/chartguide.py
+++ b/scripts/ongeki/chartguide.py
@@ -21,7 +21,11 @@ VERSION_MAPPING = {
     'RED plus': '03',
     'bright': '04',
     'bright MEMORY': '04',
-    'Re:Fresh': '05'
+    'bright MEMORY Act.1': '04',
+    'bright MEMORY Act.2': '04',
+    'bright MEMORY Act.3': '04',
+    'Re:Fresh': '05',
+    'Re:Fresh Act.2': '05'
 }
 
 PAGES = {

--- a/scripts/ongeki/game.py
+++ b/scripts/ongeki/game.py
@@ -1,7 +1,7 @@
 GAME_NAME = "ongeki"
 
-CURRENT_JP_VER = "Re:Fresh"
-CURRENT_INTL_VER = "Re:Fresh"
+CURRENT_JP_VER = "Re:Fresh Act.2"
+CURRENT_INTL_VER = "Re:Fresh Act.2"
 
 HASH_KEYS = ['image_url', 'lunatic']
 HASH_KEYS_SP = ['image_url', 'lunatic']


### PR DESCRIPTION
Resolves #1185

### Summary of Changes:
- **Scripts**:
  - Updated `CURRENT_JP_VER` and `CURRENT_INTL_VER` in `scripts/ongeki/game.py` to `Re:Fresh Act.2` so new songs fetched moving forward are labeled as `Re:Fresh Act.2`.
  - Updated `VERSION_MAPPING` in `scripts/ongeki/chartguide.py` to include `Re:Fresh Act.2` and explicit `bright MEMORY Act.1/2/3` keys.
- **Site**:
  - Updated `game_version_display` in `ongeki/src/pug/_ongeki_meta.pug` to `Re:Fresh Act.2`.
- **Data**:
  - Updated the version label to `Re:Fresh Act.2` for Ongeki songs released on or after July 23, 2026 in `ongeki/data/music-ex.json` (13 songs in total):
    - **2026-07-23**: *シークレット・シーカー*, *お返事まだカナ？おじさん構文！*, *メモリア*, *ももいろの鍵*, *熱異常*, *ユメハナビ*, *poppin’ hoppin’ flappin’☆☆☆*, *What's up? Pop!*, *Cryogenic*, *涌遊スマイルパワー*
    - **2026-08-06**: *Cthugha*, *アルメリアの鳥籠*, *それはもうらぶちゅ*