### PR TITLE
feat(ci): automate date-scoped PR creation and data isolation

### DIFF
--- a/.github/workflows/chunithm-update-constants.yml
+++ b/.github/workflows/chunithm-update-constants.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 */4 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   fetch_constants:
     name: Fetch latest chart constants from Google Sheet
@@ -36,32 +40,21 @@ jobs:
           git config --global user.name "GitHub Actions"
 
       - name: Checkout existing branch or create new
-        run : |
+        run: |
           git fetch origin
-          if git show-ref --quiet refs/remotes/origin/chunithm-staging; then
-            git switch chunithm-staging
+          if git show-ref --quiet refs/remotes/origin/chunithm/constants; then
+            git switch chunithm/constants
             git rebase origin/master
           else
-            git checkout -b chunithm-staging
+            git checkout -b chunithm/constants origin/master
           fi
-
-          # git pull origin chunithm-staging
-          # git push --force --set-upstream origin chunithm-staging
 
       - name: Run constants script and capture output
         run: |
           python -u scripts/update-const.py --chunithm --all --nocolors --escape --markdown --no_timestamp --no_verbose 2>&1 | tee output.log
 
-      - name: Extract datestamp from script output
-        id: extract_date
-        run: |
-          echo "datestamp=$(cat chunithm/data/music-ex.json | jq '.[-1].date_added | tonumber')" >> "$GITHUB_OUTPUT"
-          # echo "datestamp=$(date '+%Y%m%d')" >> "$GITHUB_OUTPUT"
-
       - name: Commit changes
         id: commit_changes
-        env:
-          UNIQUE_STRING: ${{ github.run_id }}-${{ github.run_attempt }}
         run: |
           git add .
 
@@ -70,8 +63,8 @@ jobs:
             echo "No changes. Skipping PR request"
           else
             git commit -m "data(chunithm): [bot] update song constants"
-            git push origin chunithm-staging --force-with-lease
-            echo "Commited changes."
+            git push origin chunithm/constants --force-with-lease -u
+            echo "Committed changes."
             echo "HAS_DIFFS=true" >> "$GITHUB_OUTPUT"
           fi
 
@@ -79,9 +72,9 @@ jobs:
         if: steps.commit_changes.outputs.HAS_DIFFS == 'true'
         run: |
           python scripts/post-pr.py \
-            --head "chunithm-staging" \
-            --base "${{ github.ref_name }}" \
-            --title "[Automation] CHUNITHM: Update website with updated song data (${{ steps.extract_date.outputs.DATESTAMP }})" \
+            --head "chunithm/constants" \
+            --base "master" \
+            --title "[Automation] CHUNITHM: Update chart constants" \
             --log-file "output.log"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/chunithm-update-intl.yml
+++ b/.github/workflows/chunithm-update-intl.yml
@@ -5,6 +5,10 @@ on:
     - cron: '25 0-5 * * 3-5'
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   fetch_intl:
     name: Update International ver. song data from RemyWiki
@@ -36,17 +40,14 @@ jobs:
           git config --global user.name "GitHub Actions"
 
       - name: Checkout existing branch or create new
-        run : |
+        run: |
           git fetch origin
-          if git show-ref --quiet refs/remotes/origin/chunithm-staging; then
-            git switch chunithm-staging
+          if git show-ref --quiet refs/remotes/origin/chunithm/intl; then
+            git switch chunithm/intl
             git rebase origin/master
           else
-            git checkout -b chunithm-staging
+            git checkout -b chunithm/intl origin/master
           fi
-
-          # git pull origin chunithm-staging
-          # git push --force --set-upstream origin chunithm-staging
 
       - name: Run wiki script and capture output
         run: |
@@ -55,13 +56,10 @@ jobs:
       - name: Extract datestamp from script output
         id: extract_date
         run: |
-          # echo "datestamp=$(cat chunithm/data/music-ex.json | jq '.[-1].date | tonumber')" >> "$GITHUB_OUTPUT"
           echo "datestamp=$(date '+%Y%m%d')" >> "$GITHUB_OUTPUT"
 
       - name: Commit changes
         id: commit_changes
-        env:
-          UNIQUE_STRING: ${{ github.run_id }}-${{ github.run_attempt }}
         run: |
           git add .
 
@@ -70,8 +68,8 @@ jobs:
             echo "No changes. Skipping PR request"
           else
             git commit -m "data(chunithm): [bot] add international ver. availability data ${{ steps.extract_date.outputs.DATESTAMP }}"
-            git push origin chunithm-staging --force-with-lease
-            echo "Commited changes."
+            git push origin chunithm/intl --force-with-lease -u
+            echo "Committed changes."
             echo "HAS_DIFFS=true" >> "$GITHUB_OUTPUT"
           fi
 
@@ -79,9 +77,9 @@ jobs:
         if: steps.commit_changes.outputs.HAS_DIFFS == 'true'
         run: |
           python scripts/post-pr.py \
-            --head "chunithm-staging" \
-            --base "${{ github.ref_name }}" \
-            --title "[Automation] CHUNITHM: Update website with updated song data (${{ steps.extract_date.outputs.DATESTAMP }})" \
+            --head "chunithm/intl" \
+            --base "master" \
+            --title "[Automation] CHUNITHM: Update International ver. availability (${{ steps.extract_date.outputs.DATESTAMP }})" \
             --log-file "output.log"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/chunithm-update-songs.yml
+++ b/.github/workflows/chunithm-update-songs.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 0-5 * * 3-5'
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   fetch_songs:
     name: Fetch latest song list from SEGA
@@ -35,55 +39,77 @@ jobs:
           git config --global user.email "noreply@github.com"
           git config --global user.name "GitHub Actions"
 
-      - name: Checkout existing branch or create new
-        run : |
-          git fetch origin
-          if git show-ref --quiet refs/remotes/origin/chunithm-staging; then
-            git switch chunithm-staging
-            git rebase origin/master
-          else
-            git checkout -b chunithm-staging
-          fi
-
-          # git pull origin chunithm-staging
-          # git push --force --set-upstream origin chunithm-staging
+      - name: Ensure clean state on master
+        run: |
+          git checkout master
+          git pull origin master
 
       - name: Run main script and capture output
         run: |
           python -u scripts/update-songs.py --chunithm --nocolors --escape --markdown --no_timestamp --no_verbose 2>&1 | tee output.log
 
-      - name: Extract datestamp from script output
-        id: extract_date
+      - name: Extract datestamp and prepare branch
+        id: prepare_branch
         run: |
-          echo "datestamp=$(cat chunithm/data/music-ex.json | jq '.[-1].date_added | tonumber')" >> "$GITHUB_OUTPUT"
-          # Use today's date instead because Chunithm default json doesn't have date data...
-          # echo "datestamp=$(date '+%Y%m%d')" >> "$GITHUB_OUTPUT"
+          if output=$(git status --porcelain) && [ -z "$output" ]; then
+            echo "has_diffs=false" >> "$GITHUB_OUTPUT"
+            echo "No changes found. Skipping."
+          else
+            echo "has_diffs=true" >> "$GITHUB_OUTPUT"
+            DATESTAMP=$(cat chunithm/data/music-ex.json | jq -r '.[-1].date_added // empty')
+            if [ -z "$DATESTAMP" ] || [ "$DATESTAMP" = "null" ]; then
+              DATESTAMP=$(date '+%Y%m%d')
+            fi
+            BRANCH_NAME="chunithm/update-$DATESTAMP"
+            echo "datestamp=$DATESTAMP" >> "$GITHUB_OUTPUT"
+            echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
 
+            # Create or switch to branch while carrying working tree changes
+            git fetch origin
+            if git show-ref --quiet "refs/remotes/origin/$BRANCH_NAME"; then
+              git stash
+              git switch "$BRANCH_NAME"
+              git pull origin "$BRANCH_NAME"
+              git stash pop || true
+            else
+              git checkout -b "$BRANCH_NAME"
+            fi
+          fi
 
-      - name: Commit changes
+      - name: Fetch initial wiki, chartguide, and constants data
+        if: steps.prepare_branch.outputs.has_diffs == 'true'
+        run: |
+          DATESTAMP="${{ steps.prepare_branch.outputs.datestamp }}"
+          {
+            python -u scripts/update-wiki-data.py --chunithm --date "$DATESTAMP" --nocolors --escape --markdown --noskip --no_timestamp --no_verbose || true
+            python -u scripts/update-chartguide-data.py --chunithm --date "$DATESTAMP" --nocolors --escape --markdown --no_timestamp --no_verbose || true
+            python -u scripts/update-const.py --chunithm --date "$DATESTAMP" --nocolors --escape --markdown --no_timestamp --no_verbose || true
+          } 2>&1 | tee -a output.log
+
+      - name: Commit and push changes
         id: commit_changes
-        env:
-          UNIQUE_STRING: ${{ github.run_id }}-${{ github.run_attempt }}
+        if: steps.prepare_branch.outputs.has_diffs == 'true'
         run: |
+          DATESTAMP="${{ steps.prepare_branch.outputs.datestamp }}"
+          BRANCH_NAME="${{ steps.prepare_branch.outputs.branch_name }}"
           git add .
 
           if output=$(git status --porcelain) && [ -z "$output" ]; then
-            echo "HAS_DIFFS=false" >> "$GITHUB_OUTPUT"
-            echo "No changes. Skipping PR request"
+            echo "No changes to commit."
+            echo "has_diffs=false" >> "$GITHUB_OUTPUT"
           else
-            git commit -m "data(chunithm): [bot] add song data ${{ steps.extract_date.outputs.DATESTAMP }}"
-            git push origin chunithm-staging --force-with-lease
-            echo "Commited changes."
-            echo "HAS_DIFFS=true" >> "$GITHUB_OUTPUT"
+            git commit -m "data(chunithm): [bot] add song data $DATESTAMP"
+            git push origin "$BRANCH_NAME" --force-with-lease -u
+            echo "has_diffs=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Checkout existing PR or create new
-        if: steps.commit_changes.outputs.HAS_DIFFS == 'true'
+      - name: Create or update PR
+        if: steps.prepare_branch.outputs.has_diffs == 'true' && steps.commit_changes.outputs.has_diffs == 'true'
         run: |
           python scripts/post-pr.py \
-            --head "chunithm-staging" \
-            --base "${{ github.ref_name }}" \
-            --title "[Automation] CHUNITHM: Add new songs (${{ steps.extract_date.outputs.DATESTAMP }})" \
+            --head "${{ steps.prepare_branch.outputs.branch_name }}" \
+            --base "master" \
+            --title "[Automation] CHUNITHM: Add new songs (${{ steps.prepare_branch.outputs.datestamp }})" \
             --log-file "output.log"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/chunithm-update-wiki-chartguide-all.yml
+++ b/.github/workflows/chunithm-update-wiki-chartguide-all.yml
@@ -3,6 +3,10 @@ name: "[Chunithm] Fetch from wiki (all songs)"
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   fetch_from_wiki_all:
     name: Fetch from wiki & sdvx.in (all songs)
@@ -34,17 +38,14 @@ jobs:
           git config --global user.name "GitHub Actions"
 
       - name: Checkout existing branch or create new
-        run : |
+        run: |
           git fetch origin
-          if git show-ref --quiet refs/remotes/origin/chunithm-staging; then
-            git switch chunithm-staging
+          if git show-ref --quiet refs/remotes/origin/chunithm/wiki-sync; then
+            git switch chunithm/wiki-sync
             git rebase origin/master
           else
-            git checkout -b chunithm-staging
+            git checkout -b chunithm/wiki-sync origin/master
           fi
-
-          # git pull origin chunithm-staging
-          # git push --force --set-upstream origin chunithm-staging
 
       - name: Run wiki script and capture output
         run: |
@@ -53,16 +54,8 @@ jobs:
             python -u scripts/update-chartguide-data.py --chunithm --all --nocolors --escape --markdown --no_timestamp --no_verbose
           } 2>&1 | tee output.log
 
-      - name: Extract datestamp from script output
-        id: extract_date
-        run: |
-          echo "datestamp=$(cat chunithm/data/music-ex.json | jq '.[-1].date_added | tonumber')" >> "$GITHUB_OUTPUT"
-          # echo "datestamp=$(date '+%Y%m%d')" >> "$GITHUB_OUTPUT"
-
       - name: Commit changes
         id: commit_changes
-        env:
-          UNIQUE_STRING: ${{ github.run_id }}-${{ github.run_attempt }}
         run: |
           git add .
 
@@ -71,8 +64,8 @@ jobs:
             echo "No changes. Skipping PR request"
           else
             git commit -m "data(chunithm): [bot] add song extra data (all songs)"
-            git push origin chunithm-staging --force-with-lease
-            echo "Commited changes."
+            git push origin chunithm/wiki-sync --force-with-lease -u
+            echo "Committed changes."
             echo "HAS_DIFFS=true" >> "$GITHUB_OUTPUT"
           fi
 
@@ -80,9 +73,9 @@ jobs:
         if: steps.commit_changes.outputs.HAS_DIFFS == 'true'
         run: |
           python scripts/post-pr.py \
-            --head "chunithm-staging" \
-            --base "${{ github.ref_name }}" \
-            --title "[Automation] CHUNITHM: Update website with updated song data (all songs)" \
+            --head "chunithm/wiki-sync" \
+            --base "master" \
+            --title "[Automation] CHUNITHM: Full wiki & chartguide sync" \
             --log-file "output.log"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/chunithm-update-wiki-chartguide.yml
+++ b/.github/workflows/chunithm-update-wiki-chartguide.yml
@@ -5,9 +5,13 @@ on:
     - cron: '5 */4 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   fetch_from_wiki:
-    name: Fetch from wiki & sdvx.in
+    name: Fetch from wiki & sdvx.in for active update PRs
     runs-on: ubuntu-latest
 
     steps:
@@ -35,57 +39,45 @@ jobs:
           git config --global user.email "noreply@github.com"
           git config --global user.name "GitHub Actions"
 
-      - name: Checkout existing branch or create new
-        run : |
-          git fetch origin
-          if git show-ref --quiet refs/remotes/origin/chunithm-staging; then
-            git switch chunithm-staging
-            git rebase origin/master
-          else
-            git checkout -b chunithm-staging
-          fi
-
-          # git pull origin chunithm-staging
-          # git push --force --set-upstream origin chunithm-staging
-
-      - name: Run wiki script and capture output
-        run: |
-          {
-            python -u scripts/update-wiki-data.py --chunithm --nocolors --escape --markdown --noskip --no_timestamp --no_verbose
-            python -u scripts/update-chartguide-data.py --chunithm --nocolors --escape --markdown --no_timestamp --no_verbose
-          } 2>&1 | tee output.log
-
-      - name: Extract datestamp from script output
-        id: extract_date
-        run: |
-          echo "datestamp=$(cat chunithm/data/music-ex.json | jq '.[-1].date_added | tonumber')" >> "$GITHUB_OUTPUT"
-          # echo "datestamp=$(date '+%Y%m%d')" >> "$GITHUB_OUTPUT"
-
-      - name: Commit changes
-        id: commit_changes
-        env:
-          UNIQUE_STRING: ${{ github.run_id }}-${{ github.run_attempt }}
-        run: |
-          git add .
-
-          if output=$(git status --porcelain) && [ -z "$output" ]; then
-            echo "HAS_DIFFS=false" >> "$GITHUB_OUTPUT"
-            echo "No changes. Skipping PR request"
-          else
-            git commit -m "data(chunithm): [bot] add song extra data ${{ steps.extract_date.outputs.DATESTAMP }}"
-            git push origin chunithm-staging --force-with-lease
-            echo "Commited changes."
-            echo "HAS_DIFFS=true" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Checkout existing PR or create new
-        if: steps.commit_changes.outputs.HAS_DIFFS == 'true'
-        run: |
-          python scripts/post-pr.py \
-            --head "chunithm-staging" \
-            --base "${{ github.ref_name }}" \
-            --title "[Automation] CHUNITHM: Update website with updated song data (${{ steps.extract_date.outputs.DATESTAMP }})" \
-            --log-file "output.log"
+      - name: Find and enrich open update branches
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git fetch origin
+
+          OPEN_BRANCHES=$(gh pr list --state open --base master --json headRefName --jq '.[].headRefName' | grep -E '^chunithm/update-[0-9]{8}$' || true)
+
+          if [ -z "$OPEN_BRANCHES" ]; then
+            echo "No active Chunithm update PRs found. Nothing to enrich."
+            exit 0
+          fi
+
+          for BRANCH in $OPEN_BRANCHES; do
+            echo "=========================================="
+            echo "Processing branch: $BRANCH"
+            echo "=========================================="
+
+            DATESTAMP=$(echo "$BRANCH" | grep -oE '[0-9]{8}$')
+            git checkout "$BRANCH"
+            git pull origin "$BRANCH"
+
+            {
+              python -u scripts/update-wiki-data.py --chunithm --date "$DATESTAMP" --nocolors --escape --markdown --noskip --no_timestamp --no_verbose || true
+              python -u scripts/update-chartguide-data.py --chunithm --date "$DATESTAMP" --nocolors --escape --markdown --no_timestamp --no_verbose || true
+              python -u scripts/update-const.py --chunithm --date "$DATESTAMP" --nocolors --escape --markdown --no_timestamp --no_verbose || true
+            } 2>&1 | tee output.log
+
+            git add .
+            if output=$(git status --porcelain) && [ -z "$output" ]; then
+              echo "No new wiki/chartguide/const data for $BRANCH"
+            else
+              git commit -m "data(chunithm): [bot] add song extra data $DATESTAMP"
+              git push origin "$BRANCH" --force-with-lease
+              python scripts/post-pr.py \
+                --head "$BRANCH" \
+                --base "master" \
+                --title "[Automation] CHUNITHM: Add new songs ($DATESTAMP)" \
+                --log-file "output.log"
+            fi
+          done
 

--- a/.github/workflows/maimai-update-constants.yml
+++ b/.github/workflows/maimai-update-constants.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 */4 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   fetch_constants:
     name: Fetch latest chart constants
@@ -36,32 +40,21 @@ jobs:
           git config --global user.name "GitHub Actions"
 
       - name: Checkout existing branch or create new
-        run : |
+        run: |
           git fetch origin
-          if git show-ref --quiet refs/remotes/origin/maimai-staging; then
-            git switch maimai-staging
+          if git show-ref --quiet refs/remotes/origin/maimai/constants; then
+            git switch maimai/constants
             git rebase origin/master
           else
-            git checkout -b maimai-staging
+            git checkout -b maimai/constants origin/master
           fi
-
-          # git pull origin maimai-staging
-          # git push --force --set-upstream origin maimai-staging
 
       - name: Run constants script and capture output
         run: |
           python -u scripts/update-const.py --maimai --all --nocolors --escape --markdown --no_timestamp --no_verbose 2>&1 | tee output.log
 
-      - name: Extract datestamp from script output
-        id: extract_date
-        run: |
-          echo "datestamp=$(cat maimai/data/music-ex.json | jq '.[-1].date_added | tonumber')" >> "$GITHUB_OUTPUT"
-          # echo "datestamp=$(date '+%Y%m%d')" >> "$GITHUB_OUTPUT"
-
       - name: Commit changes
         id: commit_changes
-        env:
-          UNIQUE_STRING: ${{ github.run_id }}-${{ github.run_attempt }}
         run: |
           git add .
 
@@ -70,8 +63,8 @@ jobs:
             echo "No changes. Skipping PR request"
           else
             git commit -m "data(maimai): [bot] update song constants"
-            git push origin maimai-staging --force-with-lease
-            echo "Commited changes."
+            git push origin maimai/constants --force-with-lease -u
+            echo "Committed changes."
             echo "HAS_DIFFS=true" >> "$GITHUB_OUTPUT"
           fi
 
@@ -79,9 +72,9 @@ jobs:
         if: steps.commit_changes.outputs.HAS_DIFFS == 'true'
         run: |
           python scripts/post-pr.py \
-            --head "maimai-staging" \
-            --base "${{ github.ref_name }}" \
-            --title "[Automation] maimai: Update website with updated song data (${{ steps.extract_date.outputs.DATESTAMP }})" \
+            --head "maimai/constants" \
+            --base "master" \
+            --title "[Automation] maimai: Update chart constants" \
             --log-file "output.log"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/maimai-update-intl.yml
+++ b/.github/workflows/maimai-update-intl.yml
@@ -5,6 +5,10 @@ on:
     - cron: '10 0-5 * * 3-5'
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   fetch_intl:
     name: Update International ver. song data from RemyWiki
@@ -36,17 +40,14 @@ jobs:
           git config --global user.name "GitHub Actions"
 
       - name: Checkout existing branch or create new
-        run : |
+        run: |
           git fetch origin
-          if git show-ref --quiet refs/remotes/origin/maimai-staging; then
-            git switch maimai-staging
+          if git show-ref --quiet refs/remotes/origin/maimai/intl; then
+            git switch maimai/intl
             git rebase origin/master
           else
-            git checkout -b maimai-staging
+            git checkout -b maimai/intl origin/master
           fi
-
-          # git pull origin maimai-staging
-          # git push --force --set-upstream origin maimai-staging
 
       - name: Run wiki script and capture output
         run: |
@@ -55,13 +56,10 @@ jobs:
       - name: Extract datestamp from script output
         id: extract_date
         run: |
-          # echo "datestamp=$(cat maimai/data/music-ex.json | jq '.[-1].date | tonumber')" >> "$GITHUB_OUTPUT"
           echo "datestamp=$(date '+%Y%m%d')" >> "$GITHUB_OUTPUT"
 
       - name: Commit changes
         id: commit_changes
-        env:
-          UNIQUE_STRING: ${{ github.run_id }}-${{ github.run_attempt }}
         run: |
           git add .
 
@@ -70,8 +68,8 @@ jobs:
             echo "No changes. Skipping PR request"
           else
             git commit -m "data(maimai): [bot] add international ver. availability data ${{ steps.extract_date.outputs.DATESTAMP }}"
-            git push origin maimai-staging --force-with-lease
-            echo "Commited changes."
+            git push origin maimai/intl --force-with-lease -u
+            echo "Committed changes."
             echo "HAS_DIFFS=true" >> "$GITHUB_OUTPUT"
           fi
 
@@ -79,9 +77,9 @@ jobs:
         if: steps.commit_changes.outputs.HAS_DIFFS == 'true'
         run: |
           python scripts/post-pr.py \
-            --head "maimai-staging" \
-            --base "${{ github.ref_name }}" \
-            --title "[Automation] maimai: Update website with updated song data (${{ steps.extract_date.outputs.DATESTAMP }})" \
+            --head "maimai/intl" \
+            --base "master" \
+            --title "[Automation] maimai: Update International ver. availability (${{ steps.extract_date.outputs.DATESTAMP }})" \
             --log-file "output.log"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/maimai-update-songs.yml
+++ b/.github/workflows/maimai-update-songs.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 0-5 * * 3-5'
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   fetch_songs:
     name: Fetch latest song list from SEGA
@@ -35,55 +39,76 @@ jobs:
           git config --global user.email "noreply@github.com"
           git config --global user.name "GitHub Actions"
 
-      - name: Checkout existing branch or create new
-        run : |
-          git fetch origin
-          if git show-ref --quiet refs/remotes/origin/maimai-staging; then
-            git switch maimai-staging
-            git rebase origin/master
-          else
-            git checkout -b maimai-staging
-          fi
-
-          # git pull origin maimai-staging
-          # git push --force --set-upstream origin maimai-staging
+      - name: Ensure clean state on master
+        run: |
+          git checkout master
+          git pull origin master
 
       - name: Run main script and capture output
         run: |
           python -u scripts/update-songs.py --maimai --nocolors --escape --markdown --no_timestamp --no_verbose 2>&1 | tee output.log
 
-      - name: Extract datestamp from script output
-        id: extract_date
+      - name: Extract datestamp and prepare branch
+        id: prepare_branch
         run: |
-          echo "datestamp=$(cat maimai/data/music-ex.json | jq '.[-1].date_added | tonumber')" >> "$GITHUB_OUTPUT"
-          # Use today's date instead because maimai default json doesn't have date data...
-          # echo "datestamp=$(date '+%Y%m%d')" >> "$GITHUB_OUTPUT"
+          if output=$(git status --porcelain) && [ -z "$output" ]; then
+            echo "has_diffs=false" >> "$GITHUB_OUTPUT"
+            echo "No changes found. Skipping."
+          else
+            echo "has_diffs=true" >> "$GITHUB_OUTPUT"
+            DATESTAMP=$(cat maimai/data/music-ex.json | jq -r '.[-1].date_added // empty')
+            if [ -z "$DATESTAMP" ] || [ "$DATESTAMP" = "null" ]; then
+              DATESTAMP=$(date '+%Y%m%d')
+            fi
+            BRANCH_NAME="maimai/update-$DATESTAMP"
+            echo "datestamp=$DATESTAMP" >> "$GITHUB_OUTPUT"
+            echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
 
+            # Create or switch to branch while carrying working tree changes
+            git fetch origin
+            if git show-ref --quiet "refs/remotes/origin/$BRANCH_NAME"; then
+              git stash
+              git switch "$BRANCH_NAME"
+              git pull origin "$BRANCH_NAME"
+              git stash pop || true
+            else
+              git checkout -b "$BRANCH_NAME"
+            fi
+          fi
 
-      - name: Commit changes
+      - name: Fetch initial wiki and constants data
+        if: steps.prepare_branch.outputs.has_diffs == 'true'
+        run: |
+          DATESTAMP="${{ steps.prepare_branch.outputs.datestamp }}"
+          {
+            python -u scripts/update-wiki-data.py --maimai --date "$DATESTAMP" --nocolors --escape --markdown --noskip --no_timestamp --no_verbose || true
+            python -u scripts/update-const.py --maimai --date "$DATESTAMP" --nocolors --escape --markdown --no_timestamp --no_verbose || true
+          } 2>&1 | tee -a output.log
+
+      - name: Commit and push changes
         id: commit_changes
-        env:
-          UNIQUE_STRING: ${{ github.run_id }}-${{ github.run_attempt }}
+        if: steps.prepare_branch.outputs.has_diffs == 'true'
         run: |
+          DATESTAMP="${{ steps.prepare_branch.outputs.datestamp }}"
+          BRANCH_NAME="${{ steps.prepare_branch.outputs.branch_name }}"
           git add .
 
           if output=$(git status --porcelain) && [ -z "$output" ]; then
-            echo "HAS_DIFFS=false" >> "$GITHUB_OUTPUT"
-            echo "No changes. Skipping PR request"
+            echo "No changes to commit."
+            echo "has_diffs=false" >> "$GITHUB_OUTPUT"
           else
-            git commit -m "data(maimai): [bot] add song data ${{ steps.extract_date.outputs.DATESTAMP }}"
-            git push origin maimai-staging --force-with-lease
-            echo "Commited changes."
-            echo "HAS_DIFFS=true" >> "$GITHUB_OUTPUT"
+            git commit -m "data(maimai): [bot] add song data $DATESTAMP"
+            git push origin "$BRANCH_NAME" --force-with-lease -u
+            echo "has_diffs=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Checkout existing PR or create new
-        if: steps.commit_changes.outputs.HAS_DIFFS == 'true'
+      - name: Create or update PR
+        if: steps.prepare_branch.outputs.has_diffs == 'true' && steps.commit_changes.outputs.has_diffs == 'true'
         run: |
           python scripts/post-pr.py \
-            --head "maimai-staging" \
-            --base "${{ github.ref_name }}" \
-            --title "[Automation] maimai: Add new songs (${{ steps.extract_date.outputs.DATESTAMP }})" \
+            --head "${{ steps.prepare_branch.outputs.branch_name }}" \
+            --base "master" \
+            --title "[Automation] maimai: Add new songs (${{ steps.prepare_branch.outputs.datestamp }})" \
             --log-file "output.log"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/maimai-update-wiki-all.yml
+++ b/.github/workflows/maimai-update-wiki-all.yml
@@ -3,6 +3,10 @@ name: "[maimai] Fetch from wiki (all songs)"
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   fetch_from_wiki_all:
     name: Fetch from wiki (all songs)
@@ -34,32 +38,21 @@ jobs:
           git config --global user.name "GitHub Actions"
 
       - name: Checkout existing branch or create new
-        run : |
+        run: |
           git fetch origin
-          if git show-ref --quiet refs/remotes/origin/maimai-staging; then
-            git switch maimai-staging
+          if git show-ref --quiet refs/remotes/origin/maimai/wiki-sync; then
+            git switch maimai/wiki-sync
             git rebase origin/master
           else
-            git checkout -b maimai-staging
+            git checkout -b maimai/wiki-sync origin/master
           fi
-
-          # git pull origin maimai-staging
-          # git push --force --set-upstream origin maimai-staging
 
       - name: Run wiki script and capture output
         run: |
           python -u scripts/update-wiki-data.py --maimai --all --nocolors --escape --markdown --noskip --no_timestamp --no_verbose 2>&1 | tee output.log
 
-      - name: Extract datestamp from script output
-        id: extract_date
-        run: |
-          echo "datestamp=$(cat maimai/data/music-ex.json | jq '.[-1].date_added | tonumber')" >> "$GITHUB_OUTPUT"
-          # echo "datestamp=$(date '+%Y%m%d')" >> "$GITHUB_OUTPUT"
-
       - name: Commit changes
         id: commit_changes
-        env:
-          UNIQUE_STRING: ${{ github.run_id }}-${{ github.run_attempt }}
         run: |
           git add .
 
@@ -68,8 +61,8 @@ jobs:
             echo "No changes. Skipping PR request"
           else
             git commit -m "data(maimai): [bot] add song extra data (all songs)"
-            git push origin maimai-staging --force-with-lease
-            echo "Commited changes."
+            git push origin maimai/wiki-sync --force-with-lease -u
+            echo "Committed changes."
             echo "HAS_DIFFS=true" >> "$GITHUB_OUTPUT"
           fi
 
@@ -77,9 +70,9 @@ jobs:
         if: steps.commit_changes.outputs.HAS_DIFFS == 'true'
         run: |
           python scripts/post-pr.py \
-            --head "maimai-staging" \
-            --base "${{ github.ref_name }}" \
-            --title "[Automation] maimai: Update website with updated song data (all songs)" \
+            --head "maimai/wiki-sync" \
+            --base "master" \
+            --title "[Automation] maimai: Full wiki sync" \
             --log-file "output.log"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/maimai-update-wiki.yml
+++ b/.github/workflows/maimai-update-wiki.yml
@@ -5,9 +5,13 @@ on:
     - cron: '7 */13 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   fetch_from_wiki:
-    name: Fetch from wiki
+    name: Fetch from wiki for active update PRs
     runs-on: ubuntu-latest
 
     steps:
@@ -35,54 +39,44 @@ jobs:
           git config --global user.email "noreply@github.com"
           git config --global user.name "GitHub Actions"
 
-      - name: Checkout existing branch or create new
-        run : |
-          git fetch origin
-          if git show-ref --quiet refs/remotes/origin/maimai-staging; then
-            git switch maimai-staging
-            git rebase origin/master
-          else
-            git checkout -b maimai-staging
-          fi
-
-          # git pull origin maimai-staging
-          # git push --force --set-upstream origin maimai-staging
-
-      - name: Run wiki script and capture output
-        run: |
-          python -u scripts/update-wiki-data.py --maimai --nocolors --escape --markdown --noskip --no_timestamp --no_verbose 2>&1 | tee output.log
-
-      - name: Extract datestamp from script output
-        id: extract_date
-        run: |
-          echo "datestamp=$(cat maimai/data/music-ex.json | jq '.[-1].date_added | tonumber')" >> "$GITHUB_OUTPUT"
-          # echo "datestamp=$(date '+%Y%m%d')" >> "$GITHUB_OUTPUT"
-
-      - name: Commit changes
-        id: commit_changes
-        env:
-          UNIQUE_STRING: ${{ github.run_id }}-${{ github.run_attempt }}
-        run: |
-          git add .
-
-          if output=$(git status --porcelain) && [ -z "$output" ]; then
-            echo "HAS_DIFFS=false" >> "$GITHUB_OUTPUT"
-            echo "No changes. Skipping PR request"
-          else
-            git commit -m "data(maimai): [bot] add song extra data ${{ steps.extract_date.outputs.DATESTAMP }}"
-            git push origin maimai-staging --force-with-lease
-            echo "Commited changes."
-            echo "HAS_DIFFS=true" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Checkout existing PR or create new
-        if: steps.commit_changes.outputs.HAS_DIFFS == 'true'
-        run: |
-          python scripts/post-pr.py \
-            --head "maimai-staging" \
-            --base "${{ github.ref_name }}" \
-            --title "[Automation] maimai: Update website with updated song data (${{ steps.extract_date.outputs.DATESTAMP }})" \
-            --log-file "output.log"
+      - name: Find and enrich open update branches
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git fetch origin
+
+          OPEN_BRANCHES=$(gh pr list --state open --base master --json headRefName --jq '.[].headRefName' | grep -E '^maimai/update-[0-9]{8}$' || true)
+
+          if [ -z "$OPEN_BRANCHES" ]; then
+            echo "No active maimai update PRs found. Nothing to enrich."
+            exit 0
+          fi
+
+          for BRANCH in $OPEN_BRANCHES; do
+            echo "=========================================="
+            echo "Processing branch: $BRANCH"
+            echo "=========================================="
+
+            DATESTAMP=$(echo "$BRANCH" | grep -oE '[0-9]{8}$')
+            git checkout "$BRANCH"
+            git pull origin "$BRANCH"
+
+            {
+              python -u scripts/update-wiki-data.py --maimai --date "$DATESTAMP" --nocolors --escape --markdown --noskip --no_timestamp --no_verbose || true
+              python -u scripts/update-const.py --maimai --date "$DATESTAMP" --nocolors --escape --markdown --no_timestamp --no_verbose || true
+            } 2>&1 | tee output.log
+
+            git add .
+            if output=$(git status --porcelain) && [ -z "$output" ]; then
+              echo "No new wiki/chartguide/const data for $BRANCH"
+            else
+              git commit -m "data(maimai): [bot] add song extra data $DATESTAMP"
+              git push origin "$BRANCH" --force-with-lease
+              python scripts/post-pr.py \
+                --head "$BRANCH" \
+                --base "master" \
+                --title "[Automation] maimai: Add new songs ($DATESTAMP)" \
+                --log-file "output.log"
+            fi
+          done
 

--- a/.github/workflows/ongeki-update-constants.yml
+++ b/.github/workflows/ongeki-update-constants.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 */4 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   fetch_constants:
     name: Fetch latest chart constants from Google Sheet
@@ -36,32 +40,21 @@ jobs:
           git config --global user.name "GitHub Actions"
 
       - name: Checkout existing branch or create new
-        run : |
+        run: |
           git fetch origin
-          if git show-ref --quiet refs/remotes/origin/ongeki-staging; then
-            git switch ongeki-staging
+          if git show-ref --quiet refs/remotes/origin/ongeki/constants; then
+            git switch ongeki/constants
             git rebase origin/master
           else
-            git checkout -b ongeki-staging
+            git checkout -b ongeki/constants origin/master
           fi
-
-          # git pull origin ongeki-staging
-          # git push --force --set-upstream origin ongeki-staging
 
       - name: Run constants script and capture output
         run: |
           python -u scripts/update-const.py --ongeki --all --nocolors --escape --markdown --no_timestamp --no_verbose 2>&1 | tee output.log
 
-      - name: Extract datestamp from script output
-        id: extract_date
-        run: |
-          echo "datestamp=$(cat ongeki/data/music-ex.json | jq '.[-1].date_added | tonumber')" >> "$GITHUB_OUTPUT"
-          # echo "datestamp=$(date '+%Y%m%d')" >> "$GITHUB_OUTPUT"
-
       - name: Commit changes
         id: commit_changes
-        env:
-          UNIQUE_STRING: ${{ github.run_id }}-${{ github.run_attempt }}
         run: |
           git add .
 
@@ -70,8 +63,8 @@ jobs:
             echo "No changes. Skipping PR request"
           else
             git commit -m "data(ongeki): [bot] update song constants"
-            git push origin ongeki-staging --force-with-lease
-            echo "Commited changes."
+            git push origin ongeki/constants --force-with-lease -u
+            echo "Committed changes."
             echo "HAS_DIFFS=true" >> "$GITHUB_OUTPUT"
           fi
 
@@ -79,9 +72,9 @@ jobs:
         if: steps.commit_changes.outputs.HAS_DIFFS == 'true'
         run: |
           python scripts/post-pr.py \
-            --head "ongeki-staging" \
-            --base "${{ github.ref_name }}" \
-            --title "[Automation] Ongeki: Update website with updated song data (${{ steps.extract_date.outputs.DATESTAMP }})" \
+            --head "ongeki/constants" \
+            --base "master" \
+            --title "[Automation] Ongeki: Update chart constants" \
             --log-file "output.log"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ongeki-update-songs.yml
+++ b/.github/workflows/ongeki-update-songs.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 0-5 * * 3-5'
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   fetch_songs:
     name: Fetch latest song list from SEGA
@@ -35,51 +39,77 @@ jobs:
           git config --global user.email "noreply@github.com"
           git config --global user.name "GitHub Actions"
 
-      - name: Checkout existing branch or create new
-        run : |
-          git fetch origin
-          if git show-ref --quiet refs/remotes/origin/ongeki-staging; then
-            git switch ongeki-staging
-            git rebase origin/master
-          else
-            git checkout -b ongeki-staging
-          fi
-
-          # git pull origin ongeki-staging
-          # git push --force --set-upstream origin ongeki-staging
+      - name: Ensure clean state on master
+        run: |
+          git checkout master
+          git pull origin master
 
       - name: Run main script and capture output
         run: |
           python -u scripts/update-songs.py --ongeki --nocolors --escape --markdown --no_timestamp --no_verbose 2>&1 | tee output.log
 
-      - name: Extract datestamp from script output
-        id: extract_date
-        run: echo "datestamp=$(cat ongeki/data/music-ex.json | jq '.[-1].date_added | tonumber')" >> "$GITHUB_OUTPUT"
-
-      - name: Commit changes
-        id: commit_changes
-        env:
-          UNIQUE_STRING: ${{ github.run_id }}-${{ github.run_attempt }}
+      - name: Extract datestamp and prepare branch
+        id: prepare_branch
         run: |
+          if output=$(git status --porcelain) && [ -z "$output" ]; then
+            echo "has_diffs=false" >> "$GITHUB_OUTPUT"
+            echo "No changes found. Skipping."
+          else
+            echo "has_diffs=true" >> "$GITHUB_OUTPUT"
+            DATESTAMP=$(cat ongeki/data/music-ex.json | jq -r '.[-1].date_added // empty')
+            if [ -z "$DATESTAMP" ] || [ "$DATESTAMP" = "null" ]; then
+              DATESTAMP=$(date '+%Y%m%d')
+            fi
+            BRANCH_NAME="ongeki/update-$DATESTAMP"
+            echo "datestamp=$DATESTAMP" >> "$GITHUB_OUTPUT"
+            echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
+
+            # Create or switch to branch while carrying working tree changes
+            git fetch origin
+            if git show-ref --quiet "refs/remotes/origin/$BRANCH_NAME"; then
+              git stash
+              git switch "$BRANCH_NAME"
+              git pull origin "$BRANCH_NAME"
+              git stash pop || true
+            else
+              git checkout -b "$BRANCH_NAME"
+            fi
+          fi
+
+      - name: Fetch initial wiki, chartguide, and constants data
+        if: steps.prepare_branch.outputs.has_diffs == 'true'
+        run: |
+          DATESTAMP="${{ steps.prepare_branch.outputs.datestamp }}"
+          {
+            python -u scripts/update-wiki-data.py --ongeki --date "$DATESTAMP" --nocolors --escape --markdown --noskip --no_timestamp --no_verbose || true
+            python -u scripts/update-chartguide-data.py --ongeki --date "$DATESTAMP" --nocolors --escape --markdown --no_timestamp --no_verbose || true
+            python -u scripts/update-const.py --ongeki --date "$DATESTAMP" --nocolors --escape --markdown --no_timestamp --no_verbose || true
+          } 2>&1 | tee -a output.log
+
+      - name: Commit and push changes
+        id: commit_changes
+        if: steps.prepare_branch.outputs.has_diffs == 'true'
+        run: |
+          DATESTAMP="${{ steps.prepare_branch.outputs.datestamp }}"
+          BRANCH_NAME="${{ steps.prepare_branch.outputs.branch_name }}"
           git add .
 
           if output=$(git status --porcelain) && [ -z "$output" ]; then
-            echo "HAS_DIFFS=false" >> "$GITHUB_OUTPUT"
-            echo "No changes. Skipping PR request"
+            echo "No changes to commit."
+            echo "has_diffs=false" >> "$GITHUB_OUTPUT"
           else
-            git commit -m "data(ongeki): [bot] add song data ${{ steps.extract_date.outputs.DATESTAMP }}"
-            git push origin ongeki-staging --force-with-lease
-            echo "Commited changes."
-            echo "HAS_DIFFS=true" >> "$GITHUB_OUTPUT"
+            git commit -m "data(ongeki): [bot] add song data $DATESTAMP"
+            git push origin "$BRANCH_NAME" --force-with-lease -u
+            echo "has_diffs=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Checkout existing PR or create new
-        if: steps.commit_changes.outputs.HAS_DIFFS == 'true'
+      - name: Create or update PR
+        if: steps.prepare_branch.outputs.has_diffs == 'true' && steps.commit_changes.outputs.has_diffs == 'true'
         run: |
           python scripts/post-pr.py \
-            --head "ongeki-staging" \
-            --base "${{ github.ref_name }}" \
-            --title "[Automation] Ongeki: Add new songs (${{ steps.extract_date.outputs.DATESTAMP }})" \
+            --head "${{ steps.prepare_branch.outputs.branch_name }}" \
+            --base "master" \
+            --title "[Automation] Ongeki: Add new songs (${{ steps.prepare_branch.outputs.datestamp }})" \
             --log-file "output.log"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ongeki-update-wiki-chartguide-all.yml
+++ b/.github/workflows/ongeki-update-wiki-chartguide-all.yml
@@ -3,6 +3,10 @@ name: "[Ongeki] Fetch from wiki & sdvx.in (all songs)"
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   fetch_from_wiki_all:
     name: Fetch from wiki & sdvx.in (all songs)
@@ -34,17 +38,14 @@ jobs:
           git config --global user.name "GitHub Actions"
 
       - name: Checkout existing branch or create new
-        run : |
+        run: |
           git fetch origin
-          if git show-ref --quiet refs/remotes/origin/ongeki-staging; then
-            git switch ongeki-staging
+          if git show-ref --quiet refs/remotes/origin/ongeki/wiki-sync; then
+            git switch ongeki/wiki-sync
             git rebase origin/master
           else
-            git checkout -b ongeki-staging
+            git checkout -b ongeki/wiki-sync origin/master
           fi
-
-          # git pull origin ongeki-staging
-          # git push --force --set-upstream origin ongeki-staging
 
       - name: Run wiki script and capture output
         run: |
@@ -53,14 +54,8 @@ jobs:
             python -u scripts/update-chartguide-data.py --ongeki --all --nocolors --escape --markdown --no_timestamp --no_verbose
           } 2>&1 | tee output.log
 
-      - name: Extract datestamp from script output
-        id: extract_date
-        run: echo "datestamp=$(cat ongeki/data/music-ex.json | jq '.[-1].date_added | tonumber')" >> "$GITHUB_OUTPUT"
-
       - name: Commit changes
         id: commit_changes
-        env:
-          UNIQUE_STRING: ${{ github.run_id }}-${{ github.run_attempt }}
         run: |
           git add .
 
@@ -69,8 +64,8 @@ jobs:
             echo "No changes. Skipping PR request"
           else
             git commit -m "data(ongeki): [bot] add song extra data (all songs)"
-            git push origin ongeki-staging --force-with-lease
-            echo "Commited changes."
+            git push origin ongeki/wiki-sync --force-with-lease -u
+            echo "Committed changes."
             echo "HAS_DIFFS=true" >> "$GITHUB_OUTPUT"
           fi
 
@@ -78,9 +73,9 @@ jobs:
         if: steps.commit_changes.outputs.HAS_DIFFS == 'true'
         run: |
           python scripts/post-pr.py \
-            --head "ongeki-staging" \
-            --base "${{ github.ref_name }}" \
-            --title "[Automation] Ongeki: Update website with updated song data (all songs)" \
+            --head "ongeki/wiki-sync" \
+            --base "master" \
+            --title "[Automation] Ongeki: Full wiki & chartguide sync" \
             --log-file "output.log"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ongeki-update-wiki-chartguide.yml
+++ b/.github/workflows/ongeki-update-wiki-chartguide.yml
@@ -5,9 +5,13 @@ on:
     - cron: '5 */4 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   fetch_from_wiki:
-    name: Fetch from wiki & sdvx.in
+    name: Fetch from wiki & sdvx.in for active update PRs
     runs-on: ubuntu-latest
 
     steps:
@@ -35,55 +39,45 @@ jobs:
           git config --global user.email "noreply@github.com"
           git config --global user.name "GitHub Actions"
 
-      - name: Checkout existing branch or create new
-        run : |
-          git fetch origin
-          if git show-ref --quiet refs/remotes/origin/ongeki-staging; then
-            git switch ongeki-staging
-            git rebase origin/master
-          else
-            git checkout -b ongeki-staging
-          fi
-
-          # git pull origin ongeki-staging
-          # git push --force --set-upstream origin ongeki-staging
-
-      - name: Run wiki script and capture output
-        run: |
-          {
-            python -u scripts/update-wiki-data.py --ongeki --nocolors --escape --markdown --noskip --no_timestamp --no_verbose
-            python -u scripts/update-chartguide-data.py --ongeki --nocolors --escape --markdown --no_timestamp --no_verbose
-          } 2>&1 | tee output.log
-
-      - name: Extract datestamp from script output
-        id: extract_date
-        run: echo "datestamp=$(cat ongeki/data/music-ex.json | jq '.[-1].date_added | tonumber')" >> "$GITHUB_OUTPUT"
-
-      - name: Commit changes
-        id: commit_changes
-        env:
-          UNIQUE_STRING: ${{ github.run_id }}-${{ github.run_attempt }}
-        run: |
-          git add .
-
-          if output=$(git status --porcelain) && [ -z "$output" ]; then
-            echo "HAS_DIFFS=false" >> "$GITHUB_OUTPUT"
-            echo "No changes. Skipping PR request"
-          else
-            git commit -m "data(ongeki): [bot] add song extra data ${{ steps.extract_date.outputs.DATESTAMP }}"
-            git push origin ongeki-staging --force-with-lease
-            echo "Commited changes."
-            echo "HAS_DIFFS=true" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Checkout existing PR or create new
-        if: steps.commit_changes.outputs.HAS_DIFFS == 'true'
-        run: |
-          python scripts/post-pr.py \
-            --head "ongeki-staging" \
-            --base "${{ github.ref_name }}" \
-            --title "[Automation] Ongeki: Update website with updated song data (${{ steps.extract_date.outputs.DATESTAMP }})" \
-            --log-file "output.log"
+      - name: Find and enrich open update branches
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git fetch origin
+
+          OPEN_BRANCHES=$(gh pr list --state open --base master --json headRefName --jq '.[].headRefName' | grep -E '^ongeki/update-[0-9]{8}$' || true)
+
+          if [ -z "$OPEN_BRANCHES" ]; then
+            echo "No active Ongeki update PRs found. Nothing to enrich."
+            exit 0
+          fi
+
+          for BRANCH in $OPEN_BRANCHES; do
+            echo "=========================================="
+            echo "Processing branch: $BRANCH"
+            echo "=========================================="
+
+            DATESTAMP=$(echo "$BRANCH" | grep -oE '[0-9]{8}$')
+            git checkout "$BRANCH"
+            git pull origin "$BRANCH"
+
+            {
+              python -u scripts/update-wiki-data.py --ongeki --date "$DATESTAMP" --nocolors --escape --markdown --noskip --no_timestamp --no_verbose || true
+              python -u scripts/update-chartguide-data.py --ongeki --date "$DATESTAMP" --nocolors --escape --markdown --no_timestamp --no_verbose || true
+              python -u scripts/update-const.py --ongeki --date "$DATESTAMP" --nocolors --escape --markdown --no_timestamp --no_verbose || true
+            } 2>&1 | tee output.log
+
+            git add .
+            if output=$(git status --porcelain) && [ -z "$output" ]; then
+              echo "No new wiki/chartguide/const data for $BRANCH"
+            else
+              git commit -m "data(ongeki): [bot] add song extra data $DATESTAMP"
+              git push origin "$BRANCH" --force-with-lease
+              python scripts/post-pr.py \
+                --head "$BRANCH" \
+                --base "master" \
+                --title "[Automation] Ongeki: Add new songs ($DATESTAMP)" \
+                --log-file "output.log"
+            fi
+          done
 

--- a/scripts/chunithm/songs.py
+++ b/scripts/chunithm/songs.py
@@ -80,7 +80,8 @@ def renew_music_ex_data(added_songs, updated_songs, unchanged_songs, removed_son
         _add_song_data_to_ex_data(song, local_music_ex_data)
 
         if game.ARGS.markdown:
-            print_message(f"|<img src=\"https://github.com/zvuc/otoge-db/blob/chunithm-staging/chunithm/jacket/{song['image']}?raw=true\" width=\"120\">|**{song['title']}**<br>{song['artist']}|")
+            branch_name = os.getenv('BRANCH_NAME') or os.getenv('GITHUB_HEAD_REF') or os.getenv('GITHUB_REF_NAME') or 'master'
+            print_message(f"|<img src=\"https://github.com/zvuc/otoge-db/blob/{branch_name}/chunithm/jacket/{song['image']}?raw=true\" width=\"120\">|**{song['title']}**<br>{song['artist']}|")
         else:
             lazy_print_song_header(f"{song['title']}", song_diffs, log=True)
             print_message(f"- New song added", bcolors.OKGREEN)

--- a/scripts/maimai/songs.py
+++ b/scripts/maimai/songs.py
@@ -91,7 +91,8 @@ def renew_music_ex_data(added_songs, updated_songs, unchanged_songs, removed_son
         _add_song_data_to_ex_data(song, local_music_ex_data)
 
         if game.ARGS.markdown:
-            print_message(f"|<img src=\"https://github.com/zvuc/otoge-db/blob/maimai-staging/maimai/jacket/{song['image_url']}?raw=true\" width=\"120\">|**{song['title']}**<br>{song['artist']}|")
+            branch_name = os.getenv('BRANCH_NAME') or os.getenv('GITHUB_HEAD_REF') or os.getenv('GITHUB_REF_NAME') or 'master'
+            print_message(f"|<img src=\"https://github.com/zvuc/otoge-db/blob/{branch_name}/maimai/jacket/{song['image_url']}?raw=true\" width=\"120\">|**{song['title']}**<br>{song['artist']}|")
         else:
             lazy_print_song_header(f"{song['title']}", song_diffs, log=True)
             print_message(f"- New song added", bcolors.OKGREEN)

--- a/scripts/ongeki/songs.py
+++ b/scripts/ongeki/songs.py
@@ -105,7 +105,8 @@ def renew_music_ex_data(added_songs, updated_songs, unchanged_songs, removed_son
         _add_song_data_to_ex_data(song, local_music_ex_data)
 
         if game.ARGS.markdown:
-            print_message(f"|<img src=\"https://github.com/zvuc/otoge-db/blob/ongeki-staging/ongeki/jacket/{song['image_url']}?raw=true\" width=\"120\">|**{song['title']}**<br>{song['artist']}|")
+            branch_name = os.getenv('BRANCH_NAME') or os.getenv('GITHUB_HEAD_REF') or os.getenv('GITHUB_REF_NAME') or 'master'
+            print_message(f"|<img src=\"https://github.com/zvuc/otoge-db/blob/{branch_name}/ongeki/jacket/{song['image_url']}?raw=true\" width=\"120\">|**{song['title']}**<br>{song['artist']}|")
         else:
             lazy_print_song_header(f"{song['title']}", song_diffs, log=True)
             print_message(f"- New song added", bcolors.OKGREEN)

--- a/scripts/post-pr.py
+++ b/scripts/post-pr.py
@@ -127,10 +127,11 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description="Create or comment on a pull request with automatic log chunking."
     )
-    parser.add_argument("--head", required=True, help="Head branch (e.g. maimai-staging)")
+    parser.add_argument("--head", required=True, help="Head branch (e.g. maimai/update-20260723)")
     parser.add_argument("--base", default="master", help="Base branch (default: master)")
     parser.add_argument("--title", required=True, help="Pull request title")
     parser.add_argument("--log-file", required=True, help="Path to the output log file")
+    parser.add_argument("--labels", default="", help="Comma-separated labels for new PRs (e.g. automation)")
 
     args = parser.parse_args()
 
@@ -162,7 +163,7 @@ def main() -> None:
             print(f"No existing PR found for '{args.head}'. Creating new PR...")
             pr_body_file = tmp_path / "pr_body.md"
             pr_body_file.write_text(chunks[0], encoding="utf-8")
-            res = run_gh(
+            create_cmd = [
                 "pr",
                 "create",
                 "--base",
@@ -173,7 +174,13 @@ def main() -> None:
                 args.title,
                 "--body-file",
                 str(pr_body_file),
-            )
+            ]
+            if args.labels:
+                for label in args.labels.split(","):
+                    lbl = label.strip()
+                    if lbl:
+                        create_cmd.extend(["--label", lbl])
+            res = run_gh(*create_cmd)
             print(f"Successfully created PR: {res.stdout.strip()}")
 
             if total_chunks > 1:


### PR DESCRIPTION
## Summary

This PR overhauls the automated song update CI workflows across **CHUNITHM**, **maimai**, and **Ongeki** to isolate new release PRs by datestamp and prevent out-of-scope data contamination:

### 1. Date-Scoped Update Branches
- Replaced shared `<game>-staging` branches with dedicated `<game>/update-<YYYYMMDD>` branches created directly from `master`.
- Immediately runs initial scoped wiki/chartguide/constants extraction on the new branch before opening the PR.

### 2. Targeted Multi-Day Enrichment
- Scheduled 4-hourly wiki/chartguide workflows dynamically search for open `<game>/update-*` PRs using the GitHub CLI.
- Runs `update-wiki-data.py`, `update-chartguide-data.py`, and `update-const.py` **strictly scoped to `--date <YYYYMMDD>`**, ensuring older songs in the database are not touched.

### 3. Dedicated Maintenance Pipelines
- Background constants sync from Google Sheets and full wiki syncs now push to dedicated maintenance branches (`<game>/constants`, `<game>/intl`, `<game>/wiki-sync`) against `master`.

### 4. Game-Specific Adaptations
- Omitted sdvx.in chartguide fetch for maimai to reflect that maimai does not use sdvx.in chart guides.
- Updated jacket markdown preview links in `scripts/*/songs.py` to use dynamic branch names instead of hardcoded staging URLs.
- Enhanced `scripts/post-pr.py` with optional `--labels` and robust branch handling.