### PR TITLE
refactor: update master branch references to main

### DIFF
--- a/.github/workflows/chunithm-update-constants.yml
+++ b/.github/workflows/chunithm-update-constants.yml
@@ -44,9 +44,9 @@ jobs:
           git fetch origin
           if git show-ref --quiet refs/remotes/origin/chunithm/constants; then
             git switch chunithm/constants
-            git rebase origin/master
+            git rebase origin/main
           else
-            git checkout -b chunithm/constants origin/master
+            git checkout -b chunithm/constants origin/main
           fi
 
       - name: Run constants script and capture output
@@ -73,7 +73,7 @@ jobs:
         run: |
           python scripts/post-pr.py \
             --head "chunithm/constants" \
-            --base "master" \
+            --base "main" \
             --title "[Automation] CHUNITHM: Update chart constants" \
             --log-file "output.log"
         env:

--- a/.github/workflows/chunithm-update-intl.yml
+++ b/.github/workflows/chunithm-update-intl.yml
@@ -44,9 +44,9 @@ jobs:
           git fetch origin
           if git show-ref --quiet refs/remotes/origin/chunithm/intl; then
             git switch chunithm/intl
-            git rebase origin/master
+            git rebase origin/main
           else
-            git checkout -b chunithm/intl origin/master
+            git checkout -b chunithm/intl origin/main
           fi
 
       - name: Run wiki script and capture output
@@ -78,7 +78,7 @@ jobs:
         run: |
           python scripts/post-pr.py \
             --head "chunithm/intl" \
-            --base "master" \
+            --base "main" \
             --title "[Automation] CHUNITHM: Update International ver. availability (${{ steps.extract_date.outputs.DATESTAMP }})" \
             --log-file "output.log"
         env:

--- a/.github/workflows/chunithm-update-songs.yml
+++ b/.github/workflows/chunithm-update-songs.yml
@@ -39,10 +39,10 @@ jobs:
           git config --global user.email "noreply@github.com"
           git config --global user.name "GitHub Actions"
 
-      - name: Ensure clean state on master
+      - name: Ensure clean state on main
         run: |
-          git checkout master
-          git pull origin master
+          git checkout main
+          git pull origin main
 
       - name: Run main script and capture output
         run: |
@@ -108,7 +108,7 @@ jobs:
         run: |
           python scripts/post-pr.py \
             --head "${{ steps.prepare_branch.outputs.branch_name }}" \
-            --base "master" \
+            --base "main" \
             --title "[Automation] CHUNITHM: Add new songs (${{ steps.prepare_branch.outputs.datestamp }})" \
             --log-file "output.log"
         env:

--- a/.github/workflows/chunithm-update-wiki-chartguide-all.yml
+++ b/.github/workflows/chunithm-update-wiki-chartguide-all.yml
@@ -42,9 +42,9 @@ jobs:
           git fetch origin
           if git show-ref --quiet refs/remotes/origin/chunithm/wiki-sync; then
             git switch chunithm/wiki-sync
-            git rebase origin/master
+            git rebase origin/main
           else
-            git checkout -b chunithm/wiki-sync origin/master
+            git checkout -b chunithm/wiki-sync origin/main
           fi
 
       - name: Run wiki script and capture output
@@ -74,7 +74,7 @@ jobs:
         run: |
           python scripts/post-pr.py \
             --head "chunithm/wiki-sync" \
-            --base "master" \
+            --base "main" \
             --title "[Automation] CHUNITHM: Full wiki & chartguide sync" \
             --log-file "output.log"
         env:

--- a/.github/workflows/chunithm-update-wiki-chartguide.yml
+++ b/.github/workflows/chunithm-update-wiki-chartguide.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           git fetch origin
 
-          OPEN_BRANCHES=$(gh pr list --state open --base master --json headRefName --jq '.[].headRefName' | grep -E '^chunithm/update-[0-9]{8}$' || true)
+          OPEN_BRANCHES=$(gh pr list --state open --base main --json headRefName --jq '.[].headRefName' | grep -E '^chunithm/update-[0-9]{8}$' || true)
 
           if [ -z "$OPEN_BRANCHES" ]; then
             echo "No active Chunithm update PRs found. Nothing to enrich."
@@ -75,7 +75,7 @@ jobs:
               git push origin "$BRANCH" --force-with-lease
               python scripts/post-pr.py \
                 --head "$BRANCH" \
-                --base "master" \
+                --base "main" \
                 --title "[Automation] CHUNITHM: Add new songs ($DATESTAMP)" \
                 --log-file "output.log"
             fi

--- a/.github/workflows/maimai-update-constants.yml
+++ b/.github/workflows/maimai-update-constants.yml
@@ -44,9 +44,9 @@ jobs:
           git fetch origin
           if git show-ref --quiet refs/remotes/origin/maimai/constants; then
             git switch maimai/constants
-            git rebase origin/master
+            git rebase origin/main
           else
-            git checkout -b maimai/constants origin/master
+            git checkout -b maimai/constants origin/main
           fi
 
       - name: Run constants script and capture output
@@ -73,7 +73,7 @@ jobs:
         run: |
           python scripts/post-pr.py \
             --head "maimai/constants" \
-            --base "master" \
+            --base "main" \
             --title "[Automation] maimai: Update chart constants" \
             --log-file "output.log"
         env:

--- a/.github/workflows/maimai-update-intl.yml
+++ b/.github/workflows/maimai-update-intl.yml
@@ -44,9 +44,9 @@ jobs:
           git fetch origin
           if git show-ref --quiet refs/remotes/origin/maimai/intl; then
             git switch maimai/intl
-            git rebase origin/master
+            git rebase origin/main
           else
-            git checkout -b maimai/intl origin/master
+            git checkout -b maimai/intl origin/main
           fi
 
       - name: Run wiki script and capture output
@@ -78,7 +78,7 @@ jobs:
         run: |
           python scripts/post-pr.py \
             --head "maimai/intl" \
-            --base "master" \
+            --base "main" \
             --title "[Automation] maimai: Update International ver. availability (${{ steps.extract_date.outputs.DATESTAMP }})" \
             --log-file "output.log"
         env:

--- a/.github/workflows/maimai-update-songs.yml
+++ b/.github/workflows/maimai-update-songs.yml
@@ -39,10 +39,10 @@ jobs:
           git config --global user.email "noreply@github.com"
           git config --global user.name "GitHub Actions"
 
-      - name: Ensure clean state on master
+      - name: Ensure clean state on main
         run: |
-          git checkout master
-          git pull origin master
+          git checkout main
+          git pull origin main
 
       - name: Run main script and capture output
         run: |
@@ -107,7 +107,7 @@ jobs:
         run: |
           python scripts/post-pr.py \
             --head "${{ steps.prepare_branch.outputs.branch_name }}" \
-            --base "master" \
+            --base "main" \
             --title "[Automation] maimai: Add new songs (${{ steps.prepare_branch.outputs.datestamp }})" \
             --log-file "output.log"
         env:

--- a/.github/workflows/maimai-update-wiki-all.yml
+++ b/.github/workflows/maimai-update-wiki-all.yml
@@ -42,9 +42,9 @@ jobs:
           git fetch origin
           if git show-ref --quiet refs/remotes/origin/maimai/wiki-sync; then
             git switch maimai/wiki-sync
-            git rebase origin/master
+            git rebase origin/main
           else
-            git checkout -b maimai/wiki-sync origin/master
+            git checkout -b maimai/wiki-sync origin/main
           fi
 
       - name: Run wiki script and capture output
@@ -71,7 +71,7 @@ jobs:
         run: |
           python scripts/post-pr.py \
             --head "maimai/wiki-sync" \
-            --base "master" \
+            --base "main" \
             --title "[Automation] maimai: Full wiki sync" \
             --log-file "output.log"
         env:

--- a/.github/workflows/maimai-update-wiki.yml
+++ b/.github/workflows/maimai-update-wiki.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           git fetch origin
 
-          OPEN_BRANCHES=$(gh pr list --state open --base master --json headRefName --jq '.[].headRefName' | grep -E '^maimai/update-[0-9]{8}$' || true)
+          OPEN_BRANCHES=$(gh pr list --state open --base main --json headRefName --jq '.[].headRefName' | grep -E '^maimai/update-[0-9]{8}$' || true)
 
           if [ -z "$OPEN_BRANCHES" ]; then
             echo "No active maimai update PRs found. Nothing to enrich."
@@ -74,7 +74,7 @@ jobs:
               git push origin "$BRANCH" --force-with-lease
               python scripts/post-pr.py \
                 --head "$BRANCH" \
-                --base "master" \
+                --base "main" \
                 --title "[Automation] maimai: Add new songs ($DATESTAMP)" \
                 --log-file "output.log"
             fi

--- a/.github/workflows/ongeki-update-constants.yml
+++ b/.github/workflows/ongeki-update-constants.yml
@@ -44,9 +44,9 @@ jobs:
           git fetch origin
           if git show-ref --quiet refs/remotes/origin/ongeki/constants; then
             git switch ongeki/constants
-            git rebase origin/master
+            git rebase origin/main
           else
-            git checkout -b ongeki/constants origin/master
+            git checkout -b ongeki/constants origin/main
           fi
 
       - name: Run constants script and capture output
@@ -73,7 +73,7 @@ jobs:
         run: |
           python scripts/post-pr.py \
             --head "ongeki/constants" \
-            --base "master" \
+            --base "main" \
             --title "[Automation] Ongeki: Update chart constants" \
             --log-file "output.log"
         env:

--- a/.github/workflows/ongeki-update-songs.yml
+++ b/.github/workflows/ongeki-update-songs.yml
@@ -39,10 +39,10 @@ jobs:
           git config --global user.email "noreply@github.com"
           git config --global user.name "GitHub Actions"
 
-      - name: Ensure clean state on master
+      - name: Ensure clean state on main
         run: |
-          git checkout master
-          git pull origin master
+          git checkout main
+          git pull origin main
 
       - name: Run main script and capture output
         run: |
@@ -108,7 +108,7 @@ jobs:
         run: |
           python scripts/post-pr.py \
             --head "${{ steps.prepare_branch.outputs.branch_name }}" \
-            --base "master" \
+            --base "main" \
             --title "[Automation] Ongeki: Add new songs (${{ steps.prepare_branch.outputs.datestamp }})" \
             --log-file "output.log"
         env:

--- a/.github/workflows/ongeki-update-wiki-chartguide-all.yml
+++ b/.github/workflows/ongeki-update-wiki-chartguide-all.yml
@@ -42,9 +42,9 @@ jobs:
           git fetch origin
           if git show-ref --quiet refs/remotes/origin/ongeki/wiki-sync; then
             git switch ongeki/wiki-sync
-            git rebase origin/master
+            git rebase origin/main
           else
-            git checkout -b ongeki/wiki-sync origin/master
+            git checkout -b ongeki/wiki-sync origin/main
           fi
 
       - name: Run wiki script and capture output
@@ -74,7 +74,7 @@ jobs:
         run: |
           python scripts/post-pr.py \
             --head "ongeki/wiki-sync" \
-            --base "master" \
+            --base "main" \
             --title "[Automation] Ongeki: Full wiki & chartguide sync" \
             --log-file "output.log"
         env:

--- a/.github/workflows/ongeki-update-wiki-chartguide.yml
+++ b/.github/workflows/ongeki-update-wiki-chartguide.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           git fetch origin
 
-          OPEN_BRANCHES=$(gh pr list --state open --base master --json headRefName --jq '.[].headRefName' | grep -E '^ongeki/update-[0-9]{8}$' || true)
+          OPEN_BRANCHES=$(gh pr list --state open --base main --json headRefName --jq '.[].headRefName' | grep -E '^ongeki/update-[0-9]{8}$' || true)
 
           if [ -z "$OPEN_BRANCHES" ]; then
             echo "No active Ongeki update PRs found. Nothing to enrich."
@@ -75,7 +75,7 @@ jobs:
               git push origin "$BRANCH" --force-with-lease
               python scripts/post-pr.py \
                 --head "$BRANCH" \
-                --base "master" \
+                --base "main" \
                 --title "[Automation] Ongeki: Add new songs ($DATESTAMP)" \
                 --log-file "output.log"
             fi

--- a/.github/workflows/site-build-deploy.yml
+++ b/.github/workflows/site-build-deploy.yml
@@ -2,7 +2,7 @@ name: "Build and deploy site"
 
 on:
   push:
-    branches: ["master"]
+    branches: ["main"]
 
   workflow_dispatch:
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 <p>
 	<picture>
-	  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/zvuc/otoge-db/blob/master/ongeki/img/ongeki-db-logo-2022-wob.svg?raw=true">
-	  <img alt="Ongeki DB Logo" src="https://github.com/zvuc/otoge-db/blob/master/ongeki/img/ongeki-db-logo-2022-bow.svg?raw=true" width="200">
+	  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/zvuc/otoge-db/blob/main/ongeki/img/ongeki-db-logo-2022-wob.svg?raw=true">
+	  <img alt="Ongeki DB Logo" src="https://github.com/zvuc/otoge-db/blob/main/ongeki/img/ongeki-db-logo-2022-bow.svg?raw=true" width="200">
 	</picture>
-	&nbsp; &nbsp;<img alt="Chunithm DB Logo" src="https://github.com/zvuc/otoge-db/blob/master/chunithm/img/chunithm-db-logo.svg" style="margin-bottom:10px" width="240">
-	&nbsp; &nbsp;<img alt="maimai DB Logo" src="https://github.com/zvuc/otoge-db/blob/master/maimai/img/maimai-db-logo.svg?raw=true" width="200">
+	&nbsp; &nbsp;<img alt="Chunithm DB Logo" src="https://github.com/zvuc/otoge-db/blob/main/chunithm/img/chunithm-db-logo.svg" style="margin-bottom:10px" width="240">
+	&nbsp; &nbsp;<img alt="maimai DB Logo" src="https://github.com/zvuc/otoge-db/blob/main/maimai/img/maimai-db-logo.svg?raw=true" width="200">
 </p>
 
 # OTOGE DB (音ゲーDB)

--- a/scripts/chunithm/songs.py
+++ b/scripts/chunithm/songs.py
@@ -80,7 +80,7 @@ def renew_music_ex_data(added_songs, updated_songs, unchanged_songs, removed_son
         _add_song_data_to_ex_data(song, local_music_ex_data)
 
         if game.ARGS.markdown:
-            branch_name = os.getenv('BRANCH_NAME') or os.getenv('GITHUB_HEAD_REF') or os.getenv('GITHUB_REF_NAME') or 'master'
+            branch_name = os.getenv('BRANCH_NAME') or os.getenv('GITHUB_HEAD_REF') or os.getenv('GITHUB_REF_NAME') or 'main'
             print_message(f"|<img src=\"https://github.com/zvuc/otoge-db/blob/{branch_name}/chunithm/jacket/{song['image']}?raw=true\" width=\"120\">|**{song['title']}**<br>{song['artist']}|")
         else:
             lazy_print_song_header(f"{song['title']}", song_diffs, log=True)

--- a/scripts/maimai/songs.py
+++ b/scripts/maimai/songs.py
@@ -91,7 +91,7 @@ def renew_music_ex_data(added_songs, updated_songs, unchanged_songs, removed_son
         _add_song_data_to_ex_data(song, local_music_ex_data)
 
         if game.ARGS.markdown:
-            branch_name = os.getenv('BRANCH_NAME') or os.getenv('GITHUB_HEAD_REF') or os.getenv('GITHUB_REF_NAME') or 'master'
+            branch_name = os.getenv('BRANCH_NAME') or os.getenv('GITHUB_HEAD_REF') or os.getenv('GITHUB_REF_NAME') or 'main'
             print_message(f"|<img src=\"https://github.com/zvuc/otoge-db/blob/{branch_name}/maimai/jacket/{song['image_url']}?raw=true\" width=\"120\">|**{song['title']}**<br>{song['artist']}|")
         else:
             lazy_print_song_header(f"{song['title']}", song_diffs, log=True)

--- a/scripts/ongeki/songs.py
+++ b/scripts/ongeki/songs.py
@@ -105,7 +105,7 @@ def renew_music_ex_data(added_songs, updated_songs, unchanged_songs, removed_son
         _add_song_data_to_ex_data(song, local_music_ex_data)
 
         if game.ARGS.markdown:
-            branch_name = os.getenv('BRANCH_NAME') or os.getenv('GITHUB_HEAD_REF') or os.getenv('GITHUB_REF_NAME') or 'master'
+            branch_name = os.getenv('BRANCH_NAME') or os.getenv('GITHUB_HEAD_REF') or os.getenv('GITHUB_REF_NAME') or 'main'
             print_message(f"|<img src=\"https://github.com/zvuc/otoge-db/blob/{branch_name}/ongeki/jacket/{song['image_url']}?raw=true\" width=\"120\">|**{song['title']}**<br>{song['artist']}|")
         else:
             lazy_print_song_header(f"{song['title']}", song_diffs, log=True)

--- a/scripts/post-pr.py
+++ b/scripts/post-pr.py
@@ -128,7 +128,7 @@ def main() -> None:
         description="Create or comment on a pull request with automatic log chunking."
     )
     parser.add_argument("--head", required=True, help="Head branch (e.g. maimai/update-20260723)")
-    parser.add_argument("--base", default="master", help="Base branch (default: master)")
+    parser.add_argument("--base", default="main", help="Base branch (default: main)")
     parser.add_argument("--title", required=True, help="Pull request title")
     parser.add_argument("--log-file", required=True, help="Path to the output log file")
     parser.add_argument("--labels", default="", help="Comma-separated labels for new PRs (e.g. automation)")


### PR DESCRIPTION
## Summary
Following the repository default branch rename from `master` to `main`, this PR updates all references across:
- GitHub Actions workflows in `.github/workflows/` (base branch rebasing, branch checkout, deployment triggers, and PR creation targeting)
- Python update scripts in `scripts/` (default fallback branch for markdown image URLs and `post-pr.py` base branch default)
- Documentation (`README.md` logo links)